### PR TITLE
die_?sys: fix run-together error messages

### DIFF
--- a/installer.c
+++ b/installer.c
@@ -94,7 +94,7 @@ void doit(stralloc *line)
     case 'd':
       if (mkdir(target.s,0700) == -1)
         if (errno != error_exist)
-	  strerr_die3sys(111,FATAL,"unable to mkdir ",target.s);
+	  strerr_die4sys(111,FATAL,"unable to mkdir ",target.s,": ");
       break;
 
     case 'c':
@@ -103,27 +103,27 @@ void doit(stralloc *line)
 	if (opt)
 	  return;
 	else
-	  strerr_die3sys(111,FATAL,"unable to read ",name);
+	  strerr_die4sys(111,FATAL,"unable to read ",name,": ");
       }
       buffer_init(&bufin,buffer_unixread,fdin,inbuf,sizeof(inbuf));
 
       fdout = open_trunc(target.s);
       if (fdout == -1)
-	strerr_die3sys(111,FATAL,"unable to write ",target.s);
+	strerr_die4sys(111,FATAL,"unable to write ",target.s,": ");
       buffer_init(&bufout,buffer_unixwrite,fdout,outbuf,sizeof(outbuf));
 
       switch(buffer_copy(&bufout,&bufin)) {
 	case -2:
-	  strerr_die3sys(111,FATAL,"unable to read ",name);
+	  strerr_die4sys(111,FATAL,"unable to read ",name,": ");
 	case -3:
-	  strerr_die3sys(111,FATAL,"unable to write ",target.s);
+	  strerr_die4sys(111,FATAL,"unable to write ",target.s,": ");
       }
 
       close(fdin);
       if (buffer_flush(&bufout) == -1)
-	strerr_die3sys(111,FATAL,"unable to write ",target.s);
+	strerr_die4sys(111,FATAL,"unable to write ",target.s,": ");
       if (fsync(fdout) == -1)
-	strerr_die3sys(111,FATAL,"unable to write ",target.s);
+	strerr_die4sys(111,FATAL,"unable to write ",target.s,": ");
       close(fdout);
       break;
 
@@ -132,9 +132,9 @@ void doit(stralloc *line)
   }
 
   if (chown(target.s,uid,gid) == -1)
-    strerr_die3sys(111,FATAL,"unable to chown ",target.s);
+    strerr_die4sys(111,FATAL,"unable to chown ",target.s,": ");
   if (chmod(target.s,mode) == -1)
-    strerr_die3sys(111,FATAL,"unable to chmod ",target.s);
+    strerr_die4sys(111,FATAL,"unable to chmod ",target.s,": ");
 }
 
 char buf[256];
@@ -152,7 +152,7 @@ int main(int argc,char **argv)
 
   for (;;) {
     if (getln(&in,&line,&match,'\n') == -1)
-      strerr_die2sys(111,FATAL,"unable to read input");
+      strerr_die2sys(111,FATAL,"unable to read input: ");
     if (line.len > 0)
       line.s[--line.len] = 0;
     doit(&line);

--- a/supervise.c
+++ b/supervise.c
@@ -69,7 +69,7 @@ static int stat_exists(const char *path)
 
 static void die_nomem(void)
 {
-  strerr_die2sys(111,FATAL,"unable to allocate memory");
+  strerr_die2sys(111,FATAL,"unable to allocate memory: ");
 }
 
 static void trigger(void)

--- a/svok.c
+++ b/svok.c
@@ -20,7 +20,7 @@ int main(int argc,char **argv)
   if (!svpath_init())
     strerr_die4sys(111,FATAL,"unable to setup control path for ",argv[1],": ");
   if ((fnok = svpath_make("/ok")) == 0)
-    strerr_die2sys(111,FATAL,"unable to allocate memory");
+    strerr_die2sys(111,FATAL,"unable to allocate memory: ");
   fd = open_write(fnok);
   if (fd == -1) {
     if (errno == error_noent) _exit(100);

--- a/svstat.c
+++ b/svstat.c
@@ -23,7 +23,7 @@ int check_log = -1;
 
 static void die_nomem(void)
 {
-  strerr_die2sys(111,FATAL,"unable to allocate memory");
+  strerr_die2sys(111,FATAL,"unable to allocate memory: ");
 }
 
 static void die_usage(void)

--- a/svup.c
+++ b/svup.c
@@ -54,7 +54,7 @@ int main(int argc,const char *const *argv)
     strerr_die4sys(111,FATAL,"unable to setup control path for ",argv[1],": ");
 
   if ((fn = svpath_make("/ok")) == 0)
-    strerr_die2sys(111,FATAL,"unable to allocate memory");
+    strerr_die2sys(111,FATAL,"unable to allocate memory: ");
   fd = open_write(fn);
   if (fd == -1) {
     if (errno == error_noent) _exit(100);
@@ -64,7 +64,7 @@ int main(int argc,const char *const *argv)
   close(fd);
 
   if ((fn = svpath_make("/status")) == 0)
-    strerr_die2sys(111,FATAL,"unable to allocate memory");
+    strerr_die2sys(111,FATAL,"unable to allocate memory: ");
   fd = open_read(fn);
   if (fd == -1) {
     if (errno == error_noent) _exit(100);


### PR DESCRIPTION
This...
installer: fatal: unable to write multilogtext busy

becomes...
installer: fatal: unable to write multilog: text busy

Once I found that one, grep found 14 more.
