### PR TITLE
multilog: Increase the file size limit to 2147483647

### DIFF
--- a/multilog.8
+++ b/multilog.8
@@ -225,7 +225,7 @@ will also decide that
 is big enough if it sees a newline within 2000 bytes of the maximum file size;
 it tries to finish log files at line boundaries.)
 .I size
-must be between 4096 and 16777215. The default maximum file size is 99999. 
+must be between 4096 and 2147483647. The default maximum file size is 99999.
 
 In versions 0.75 and above: If
 .B multilog

--- a/multilog.c
+++ b/multilog.c
@@ -407,7 +407,7 @@ void c_init(char **script)
     if (script[i][0] == 's') {
       scan_ulong(script[i] + 1,&size);
       if (size < 4096) size = 4096;
-      if (size > 16777215) size = 16777215;
+      if (size > 2147483647) size = 2147483647;
     }
     else if (script[i][0] == 'n') {
       scan_ulong(script[i] + 1,&num);


### PR DESCRIPTION
My coworker wants to increase the maximum file size to 1GiB, but multilog limit the max size to 16MiB.
It's too small to use in some situations.
