### PR TITLE
Fix reporting of the 1900 years beyond 2147483647.

### DIFF
--- a/tai64nlocal.c
+++ b/tai64nlocal.c
@@ -53,7 +53,7 @@ int main()
       }
       secs -= 4611686018427387914ULL;
       t = localtime(&secs);
-      out(num,fmt_ulong(num,1900 + t->tm_year));
+      out(num,fmt_ulong(num,1900UL + t->tm_year));
       out("-",1); out(num,fmt_uint0(num,1 + t->tm_mon,2));
       out("-",1); out(num,fmt_uint0(num,t->tm_mday,2));
       out(" ",1); out(num,fmt_uint0(num,t->tm_hour,2));


### PR DESCRIPTION
Not that it matters much for a few more years, but once t->tm_year becomes sufficiently large, adding 1900 to it causes the result to wrap beyond INT_MAX and become negative. Once sent to fmt_ulong, the negative number becomes an extremely large positive year.

Last good second...
$ echo '@40f0c29d868c43d900000000' | tai64nlocal
2147483647-12-31 23:59:59.000000000

First bad second...
$ echo '@40f0c29d868c43da00000000' | tai64nlocal
18446744071562067968-01-01 00:00:000000000

Same second, after patch...
$ echo '@40f0c29d868c43da00000000' | tai64nlocal
2147483648-01-01 00:00:00.000000000
.
