### PR TITLE
(Re)add DJB's original fifo program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ envdir
 envini
 envuidgid
 fghack
+fifo
 hasattribute.h
 hasflock.h
 hasmemrchr.h

--- a/BIN
+++ b/BIN
@@ -2,6 +2,7 @@ c:::755:/:envdir:
 c:::755:/:envini:
 c:::755:/:envuidgid:
 c:::755:/:fghack:
+c:::755:/:fifo:
 c:::755:/:multilog:
 c:::755:/:pgrphack:
 c:::755:/:readproctitle:

--- a/MAN
+++ b/MAN
@@ -3,6 +3,7 @@ c:::644:/man8/:envdir.8:
 c:::644:/man8/:envini.8:
 c:::644:/man8/:envuidgid.8:
 c:::644:/man8/:fghack.8:
+c:::644:/man8/:fifo.8:
 c:::644:/man8/:multilog.8:
 c:::644:/man8/:pgrphack.8:
 c:::644:/man8/:readproctitle.8:

--- a/fifo.8
+++ b/fifo.8
@@ -1,0 +1,36 @@
+.TH fifo 8
+.SH NAME
+fifo \- create and read a named pipe writing to stdout.
+.SH SYNOPSIS
+.B fifo
+.I file
+.SH DESCRIPTION
+.B fifo
+prints everything fed to the named pipe
+.I file
+to standard
+output.
+.I file
+is held open for writing so that other programs can
+repeatedly open and close.
+
+.B fifo
+creates
+.I file
+with mode 0600 if it does not exist.
+
+.B fifo
+does not read stardard input.
+
+.B fifo
+normally runs forever.
+.SH EXIT CODES
+.B fifo
+exits 100 for improper usage with a message on standard error.
+
+.B fifo
+exits 111 for any other problems with a message on standard error.
+.SH SEE ALSO
+mkfifo(1),
+mkfifo(2),
+pipe(7)

--- a/fifo.8
+++ b/fifo.8
@@ -20,7 +20,7 @@ creates
 with mode 0600 if it does not exist.
 
 .B fifo
-does not read stardard input.
+does not read standard input.
 
 .B fifo
 normally runs forever.

--- a/fifo.do
+++ b/fifo.do
@@ -1,0 +1,2 @@
+dependon load fifomain.o unix.a byte.a
+formake './load fifo fifomain.o unix.a byte.a'

--- a/fifo=x
+++ b/fifo=x
@@ -1,0 +1,2 @@
+unix.a
+byte.a

--- a/fifomain.c
+++ b/fifomain.c
@@ -1,0 +1,60 @@
+#include <sys/types.h>
+#include <sys/time.h>
+#include "fifo.h"
+#include "open.h"
+#include "strerr.h"
+#include "error.h"
+#include "substdio.h"
+#include "readwrite.h"
+#include "ndelay.h"
+
+#define FATAL "fifo: fatal: "
+
+char *fn;
+int fd;
+int fdwrite;
+
+char outbuf[1024];
+substdio ssout = SUBSTDIO_FDBUF(write,1,outbuf,sizeof outbuf);
+
+char inbuf[1024];
+substdio ssin;
+
+int myread(fd,buf,len) int fd; char *buf; int len;
+{
+  if (substdio_flush(&ssout) == -1) return -1;
+  return read(fd,buf,len);
+}
+
+void main(argc,argv)
+int argc;
+char **argv;
+{
+  fn = argv[1];
+  if (!fn)
+    strerr_die1x(100,"fifo: usage: fifo filename");
+
+  if (fifo_make(fn,0600) == -1)
+    if (errno != error_exist)
+      strerr_die4sys(111,FATAL,"unable to create ",fn,": ");
+
+  fd = open_read(fn);
+  if (fd == -1)
+    strerr_die4sys(111,FATAL,"unable to open ",fn," for reading: ");
+
+  fdwrite = open_write(fn);
+  if (fdwrite == -1)
+    strerr_die4sys(111,FATAL,"unable to open ",fn," for writing: ");
+
+  ndelay_off(fd);
+  substdio_fdbuf(&ssin,myread,fd,inbuf,sizeof inbuf);
+
+  switch (substdio_copy(&ssout,&ssin)) {
+    case -2:
+      strerr_die4sys(111,FATAL,"unable to read ",fn,": ");
+    case -3:
+      strerr_die2sys(111,FATAL,"unable to write output: ");
+    case 0:
+      strerr_die3x(111,FATAL,"end of file on ",fn);
+  }
+}

--- a/fifomain.c
+++ b/fifomain.c
@@ -36,24 +36,24 @@ char **argv;
 
   if (fifo_make(fn,0600) == -1)
     if (errno != error_exist)
-      strerr_die4sys(111,FATAL,"unable to create ",fn,": ");
+      strerr_die3sys(111,FATAL,"unable to create ",fn);
 
   fd = open_read(fn);
   if (fd == -1)
-    strerr_die4sys(111,FATAL,"unable to open ",fn," for reading: ");
+    strerr_die4sys(111,FATAL,"unable to open ",fn," for reading");
 
   fdwrite = open_write(fn);
   if (fdwrite == -1)
-    strerr_die4sys(111,FATAL,"unable to open ",fn," for writing: ");
+    strerr_die4sys(111,FATAL,"unable to open ",fn," for writing");
 
   ndelay_off(fd);
   buffer_init(&ssin,myread,fd,inbuf,sizeof inbuf);
 
   switch (buffer_copy(&ssout,&ssin)) {
     case -2:
-      strerr_die4sys(111,FATAL,"unable to read ",fn,": ");
+      strerr_die3sys(111,FATAL,"unable to read ",fn);
     case -3:
-      strerr_die2sys(111,FATAL,"unable to write output: ");
+      strerr_die2sys(111,FATAL,"unable to write output");
     case 0:
       strerr_die3x(111,FATAL,"end of file on ",fn);
   }

--- a/fifomain.c
+++ b/fifomain.c
@@ -11,7 +11,7 @@
 #define FATAL "fifo: fatal: "
 
 char *fn;
-int fd;
+int fdread;
 int fdwrite;
 
 char outbuf[1024];
@@ -38,16 +38,16 @@ char **argv;
     if (errno != error_exist)
       strerr_die3sys(111,FATAL,"unable to create ",fn);
 
-  fd = open_read(fn);
-  if (fd == -1)
+  fdread = open_read(fn);
+  if (fdread == -1)
     strerr_die4sys(111,FATAL,"unable to open ",fn," for reading");
 
   fdwrite = open_write(fn);
   if (fdwrite == -1)
     strerr_die4sys(111,FATAL,"unable to open ",fn," for writing");
 
-  ndelay_off(fd);
-  buffer_init(&ssin,myread,fd,inbuf,sizeof inbuf);
+  ndelay_off(fdread);
+  buffer_init(&ssin,myread,fdread,inbuf,sizeof inbuf);
 
   switch (buffer_copy(&ssout,&ssin)) {
     case -2:

--- a/man.do
+++ b/man.do
@@ -3,6 +3,7 @@ envdir.8 \
 envini.8 \
 envuidgid.8 \
 fghack.8 \
+fifo.8 \
 multilog.8 \
 pgrphack.8 \
 readproctitle.8 \

--- a/programs.do
+++ b/programs.do
@@ -1,3 +1,3 @@
-dependon envdir envini envuidgid fghack installer matchtest multilog pgrphack \
-	readproctitle setlock setuidgid sleeper softlimit supervise svc \
+dependon envdir envini envuidgid fghack fifo installer matchtest multilog \
+	pgrphack readproctitle setlock setuidgid sleeper softlimit supervise svc \
 	svok svscan svscanboot svstat svup tai64n tai64nlocal

--- a/rts.tests/fifo.exp
+++ b/rts.tests/fifo.exp
@@ -9,8 +9,8 @@ fifo: fatal: end of file on pipe
 hi there
 fifo: fatal: end of file on pipe
 --- fifo complains about reading
-fifo: fatal: unable to open pipe for reading: : access denied
+fifo: fatal: unable to open pipe for reading: access denied
 111
 --- fifo complains about writing
-fifo: fatal: unable to open pipe for writing: : access denied
+fifo: fatal: unable to open pipe for writing: access denied
 111

--- a/rts.tests/fifo.exp
+++ b/rts.tests/fifo.exp
@@ -1,0 +1,16 @@
+--- fifo requires arguments
+fifo: usage: fifo filename
+100
+--- fifo complains about files
+fifo: fatal: end of file on pipe
+111
+--- fifo dies at end of pipe
+0
+hi there
+fifo: fatal: end of file on pipe
+--- fifo complains about reading
+fifo: fatal: unable to open pipe for reading: : access denied
+111
+--- fifo complains about writing
+fifo: fatal: unable to open pipe for writing: : access denied
+111

--- a/rts.tests/fifo.sh
+++ b/rts.tests/fifo.sh
@@ -1,0 +1,30 @@
+echo '--- fifo requires arguments'
+fifo
+echo $?
+
+echo '--- fifo complains about files'
+rm -f pipe
+touch pipe
+fifo pipe
+echo $?
+
+echo '--- fifo dies at end of pipe'
+rm -f pipe fifo.out
+fifo pipe > fifo.out 2>&1 &
+fifopid=$!
+echo $?
+echo 'hi there' > pipe
+cat fifo.out
+kill $fifopid >/dev/null 2>&1
+wait >/dev/null 2>&1
+
+echo '--- fifo complains about reading'
+chmod 000 pipe
+fifo pipe
+echo $?
+
+echo '--- fifo complains about writing'
+chmod 400 pipe
+fifo pipe
+echo $?
+

--- a/rts.tests/fifo.sh
+++ b/rts.tests/fifo.sh
@@ -14,6 +14,7 @@ fifo pipe > fifo.out 2>&1 &
 fifopid=$!
 echo $?
 echo 'hi there' > pipe
+sleep 1
 cat fifo.out
 kill $fifopid >/dev/null 2>&1
 wait >/dev/null 2>&1


### PR DESCRIPTION
This is a redux of my previous request. Well, actually it's a clean restart. This version sticks to the original fifo interface and works very well in conjuction with encore features.

As mentioned previously, this patch was motivated by the need to hold a named pipe open for use as an Nginx log target. And since Nginx opens and closes its logs for every entry, using multilog isn't feasible because it exits in such cases.

In my particular usage, I've created an nginx service directory and configured Nginx to use log/pipe as its log file.

> cat run
> # !/bin/sh
> 
> exec >&2
> exec nginx
> 
> cat log/run
> # !/bin/sh
> 
> exec </dev/null
> exec fifo pipe
> 
> cat log/log
> # !/bin/sh
> 
> exec multilog t ./main

There's a bit more to it since I'm running nginx and fifo/multilog as different users, but those details aren't really relevant here. The point is that this is simple, it works, and it doesn't introduce all the potentially breakable parts of my previous attempt.
