### PR TITLE
rts.tests: Ensure sleeper running STOP handler before TERM handler

### DIFF
--- a/rts.tests/supervise-stop.sh
+++ b/rts.tests/supervise-stop.sh
@@ -9,7 +9,8 @@ rm -f test.sv/stop
 echo
 
 echo '--- supervise stops log after main'
-( echo '#!/bin/sh'; echo 'exec ../../sleeper' ) >test.sv/log
+( echo '#!/bin/sh'; echo sleep 2; echo svc -dx . ) >test.sv/run
+( echo '#!/bin/sh'; echo '(sleep 1; kill -STOP $$) &'; echo 'exec ../../sleeper' ) >test.sv/log
 chmod +x test.sv/log
 supervise test.sv
 wait

--- a/rts.tests/svc.sh
+++ b/rts.tests/svc.sh
@@ -22,6 +22,8 @@ svc -2 test.sv
 sleep 1
 svc -w test.sv
 sleep 1
+svc -p test.sv
+sleep 1
 svc -d test.sv
 sleep 1
 svc -xk test.sv


### PR DESCRIPTION
When supervise do signal(killpid, SIGTERM) and then signal(killpid, SIGCONT), catch_sig(SIGTERM) can be finished before catch_sig(SIGCONT) in sleeper. With this patch, catch_sig(SIGCONT) can be started before catch_sig(SIGTERM).

This patch may resolve issue #25 "Intermittent test failure with CONT signal". But it is NOT the perfect resolution because catch_sig(SIGCONT) can be interrupted by catch_sig(SIGTERM) (e.g., confirmed on AIX 6.1).
