### PR TITLE
rts.tests: Portablity fix for Solaris 10 /bin/sh

### DIFF
--- a/rts.tests/svscan.sh
+++ b/rts.tests/svscan.sh
@@ -13,7 +13,7 @@ EOF
 
 catexe svc1/log <<EOF
 #!/bin/sh
-cat > output
+exec cat > output
 EOF
 
 catexe svc2/run <<EOF
@@ -23,7 +23,7 @@ EOF
 
 catexe svc2/log/run <<EOF
 #!/bin/sh
-cat > ../output
+exec cat > ../output
 EOF
 
 ln -s `pwd`/svc[0-9] service/
@@ -41,7 +41,7 @@ kill $svscanpid
 wait >/dev/null 2>&1
 
 svc -dx svc[0-9] svc2/log
-until ! svok svc0 && ! svok svc1 && ! svok svc2 && ! svok svc2/log
+while svok svc0 || svok svc1 || svok svc2 || svok svc2/log
 do
   sleep 1
 done


### PR DESCRIPTION
On Solaris 10 and older, rts.tests fails by the following
Solaris /bin/sh specifications:
- /bin/sh does not exit immediately on signals (SIGTERM and so on)
  if a foreground process is remained.
- '!' is not a reserved word and has no special meaning
  (except in '[...]')
