### PR TITLE
svscan sigterm

### DIFF
--- a/rts.tests/svscan-sigterm.exp
+++ b/rts.tests/svscan-sigterm.exp
@@ -1,0 +1,52 @@
+--- svscan handles sigterm
+
+--- svscanboot started
+
+--- svscanboot pid looks sane
+
+--- svscan started
+
+--- svscan pid looks sane
+
+--- readproctitle started
+
+--- readproctitle pid looks sane
+
+--- svscanboot is running
+
+--- svscan is running
+
+--- readproctitle is running
+
+--- supervise svc0 is running
+
+--- supervise svc1 is running
+
+--- supervise svc1/log is running
+
+--- sigterm sent
+
+--- supervise svc0 is down
+
+--- supervise svc1 is down
+
+--- supervise svc1/log is down
+
+--- svscan is stopped
+
+--- readproctitle is stopped
+
+--- svscanboot is stopped
+
+--- svscanboot log
+
+--- svc0 log
+svc0 ran
+
+--- svc1 main log
+svc1-main ran
+
+--- svc1 log log
+svc1-log ran
+
+

--- a/rts.tests/svscan-sigterm.exp
+++ b/rts.tests/svscan-sigterm.exp
@@ -24,6 +24,8 @@
 
 --- supervise svc1/log is running
 
+--- supervise svc2 is running
+
 --- sigterm sent
 
 --- supervise svc0 is down
@@ -31,6 +33,8 @@
 --- supervise svc1 is down
 
 --- supervise svc1/log is down
+
+--- supervise svc2 is down
 
 --- svscan is stopped
 
@@ -52,6 +56,16 @@ Caught TERM
 
 --- svc1 log log
 svc1-log ran
+Caught CONT
+Caught TERM
+
+--- svc2 main log
+svc2-main ran
+Caught CONT
+Caught TERM
+
+--- svc2 log log
+svc2-log ran
 Caught CONT
 Caught TERM
 

--- a/rts.tests/svscan-sigterm.exp
+++ b/rts.tests/svscan-sigterm.exp
@@ -2,13 +2,13 @@
 
 --- svscanboot started
 
---- svscanboot pid looks sane
-
 --- svscan started
 
---- svscan pid looks sane
-
 --- readproctitle started
+
+--- svscanboot pid looks sane
+
+--- svscan pid looks sane
 
 --- readproctitle pid looks sane
 
@@ -68,5 +68,4 @@ Caught TERM
 svc2-log ran
 Caught CONT
 Caught TERM
-
 

--- a/rts.tests/svscan-sigterm.exp
+++ b/rts.tests/svscan-sigterm.exp
@@ -42,11 +42,17 @@
 
 --- svc0 log
 svc0 ran
+Caught CONT
+Caught TERM
 
 --- svc1 main log
 svc1-main ran
+Caught CONT
+Caught TERM
 
 --- svc1 log log
 svc1-log ran
+Caught CONT
+Caught TERM
 
 

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -221,25 +221,32 @@ echo '--- supervise svc2 is down'
 timed_ok svc2
 echo
 
+timed_ng() {
+  if [ $1 -ne 0 ]; then
+    for i in 10 9 8 7 6 5 4 3 2 1 0; do
+      if ! kill -0 $1 2>/dev/null; then
+        break
+      fi
+      if [ $i -eq 0 ]; then
+        echo no
+        kill -HUP $1
+        break
+      fi
+      sleep 1
+    done
+  fi
+}
+
 echo '--- svscan is stopped'
-if [ $svscanpid -ne 0 ]; then
-  kill -0 $svscanpid 2>/dev/null \
-  && echo no
-fi
+timed_ng $svscanpid
 echo
 
 echo '--- readproctitle is stopped'
-if [ $readproctitlepid -ne 0 ]; then
-  kill -0 $readproctitlepid 2>/dev/null \
-  && echo no
-fi
+timed_ng $readproctitlepid
 echo
 
 echo '--- svscanboot is stopped'
-if [ $svscanbootpid -ne 0 ]; then
-  kill -0 $svscanbootpid 2>/dev/null \
-  && echo no
-fi
+timed_ng $svscanbootpid
 echo
 
 echo '--- svscanboot log'

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -43,9 +43,12 @@ sed -r                                      \
   -e 's,^exec 2?>.+,,'                      \
   -e 's,/command/svc -dx .+,,g'             \
   -e 's,/?service,service,g'                \
-  -e 's,readproctitle..*,& \&\n,'           \
-  -e '$aecho $! > readproctitle.pid'        \
-  -e '$await'                               \
+  -e 's,readproctitle..*,& \& \
+,'                                          \
+  -e '$a\
+echo $! > readproctitle.pid'                \
+  -e '$a\
+wait'                                       \
 < ../../svscanboot                          \
 | catexe svscanboot
 test -x svscanboot || die "Could not create svscanboot stub"

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -1,0 +1,255 @@
+# TODO:
+#   * how do we know logs stop *after* main?
+#
+#   * if logging with multilog (which exits at end of stdin), will a new
+#     multilog be created after the main supervise exits, but before the
+#     log supervise is signaled? if so, can we avoid it?
+#
+
+echo '--- svscan handles sigterm'
+echo
+
+mkdir test.boot          || die "Could not create test.boot"
+mkdir test.boot/service  || die "Could not create test.boot/service"
+mkdir test.boot/svc0     || die "Could not create test.boot/svc0"
+mkdir test.boot/svc1     || die "Could not create test.boot/svc1"
+mkdir test.boot/svc1/log || die "Could not create test.boot/svc1/log"
+
+cd test.boot || die "Could not change to test.boot"
+
+ln -s ../svc0 service || die "Could not link svc0"
+ln -s ../svc1 service || die "Could not link svc1"
+
+catexe svscan <<'EOF' || die "Could not create svscan wrapper"
+#!/bin/sh
+PATH=`echo $PATH | cut -d':' -f2-`
+exec env - PATH=$PATH svscan $@ &
+echo $! > svscan.pid
+EOF
+
+# FIXME: this doesnt work. get the pid in svscanboot instead.
+#catexe readproctitle <<'EOF' || die "Could not create readproctitle wrapper"
+##!/bin/sh
+#exec >readproctitle.log
+#exec 2>&1
+#PATH=`echo $PATH | cut -d':' -f2-`
+#exec env - PATH=$PATH readproctitle $@ &
+#echo $! > test.boot/readproctitle.pid
+#EOF
+
+test -x ../../svscanboot || die "Could not find svscanboot source"
+sed -r                                      \
+  -e 's,PATH=/,PATH=.:..:../..:../../..:/,' \
+  -e 's,^exec 2?>.+,,'                      \
+  -e 's,/command/svc -dx .+,,g'             \
+  -e 's,/?service,service,g'                \
+  -e 's,readproctitle..*,& \&\n,'           \
+  -e '$aecho $! > readproctitle.pid'        \
+  -e '$await'                               \
+< ../../svscanboot                          \
+| catexe svscanboot
+test -x svscanboot || die "Could not create svscanboot stub"
+
+catexe svc0/run <<'EOF' || die "Could not create svc0/run script"
+#!/bin/sh
+echo svc0 ran >> ../svc0.log
+EOF
+
+catexe svc1/run <<'EOF' || die "Could not create svc1/run script"
+#!/bin/sh
+echo svc1-main ran >> ../svc1-main.log
+EOF
+
+catexe svc1/log/run <<'EOF' || die "Could not create svc1/log/run script"
+#!/bin/sh
+echo svc1-log ran >> ../../svc1-log.log
+EOF
+
+echo '--- svscanboot started'
+./svscanboot service > svscanboot.log 2>&1 &
+svscanbootpid=$!
+echo
+
+echo '--- svscanboot pid looks sane'
+if [ `echo $svscanbootpid | grep -E '^[1-9][0-9]{0,4}$' | wc -l` != "1" ]; then
+  echo no
+  svscanbootpid=0
+elif [ $svscanbootpid -le 1 ] || [ $svscanbootpid -ge 65536 ]; then
+  echo no
+  svscanbootpid=0
+fi
+echo
+
+echo '--- svscan started'
+for i in 10 9 8 7 6 5 4 3 2 1 0; do
+  if [ -f svscan.pid ]; then
+    svscanpid=`cat svscan.pid`
+    break
+  fi
+  if [ $i -eq 0 ]; then
+    echo no
+    svscanpid=0
+    break
+  fi
+  sleep 1
+done
+echo
+
+echo '--- svscan pid looks sane'
+if [ `echo $svscanpid | grep -E ^[1-9][0-9]*$ | wc -l` != '1' ]
+then
+  echo no
+  svscanpid=0
+elif [ $svscanpid -le 1 ] || [ $svscanpid -ge 65536 ]
+then
+  echo no
+  svscanpid=0
+fi
+echo
+
+echo '--- readproctitle started'
+for i in 10 9 8 7 6 5 4 3 2 1 0; do
+  if [ -f readproctitle.pid ]; then
+    readproctitlepid=`cat readproctitle.pid`
+    break
+  fi
+  if [ $i -eq 0 ]; then
+    echo no
+    readproctitlepid=0
+    break
+  fi
+  sleep 1
+done
+echo
+
+echo '--- readproctitle pid looks sane'
+if [ `echo $readproctitlepid | grep -E ^[1-9][0-9]*$ | wc -l` != '1' ]
+then
+  echo no
+  readproctitlepid=0
+elif [ $readproctitlepid -le 1 ] || [ $readproctitlepid -ge 65536 ]
+then
+  echo no
+  readproctitlepid=0
+fi
+echo
+
+echo '--- svscanboot is running'
+if ! kill -0 $svscanbootpid; then
+  echo no
+  svscanbootpid=0
+fi
+echo
+
+echo '--- svscan is running'
+if ! kill -0 $svscanpid; then
+  echo no
+  svscanpid=0
+fi
+echo
+
+echo '--- readproctitle is running'
+if ! kill -0 $readproctitlepid; then
+  echo no
+  readproctitlepid=0
+fi
+echo
+
+echo '--- supervise svc0 is running'
+svok svc0 || echo no
+echo
+
+echo '--- supervise svc1 is running'
+svok svc1 || echo no
+echo
+
+echo '--- supervise svc1/log is running'
+svok svc1/log || echo no
+echo
+
+echo '--- sigterm sent'
+kill -TERM $svscanpid || echo no
+echo
+
+echo '--- supervise svc0 is down'
+for i in 10 9 8 7 6 5 4 3 2 1 0; do
+  if ! svok svc0; then
+    break
+  fi
+  if [ $i -eq 0 ]; then
+    echo no
+    svc -dx svc0
+    break
+  fi
+  sleep 1
+done
+echo
+
+echo '--- supervise svc1 is down'
+for i in 10 9 8 7 6 5 4 3 2 1 0; do
+  if ! svok svc1; then
+    break
+  fi
+  if [ $i -eq 0 ]; then
+    echo no
+    svc -dx svc1
+    break
+  fi
+  sleep 1
+done
+echo
+
+echo '--- supervise svc1/log is down'
+for i in 10 9 8 7 6 5 4 3 2 1 0; do
+  if ! svok svc1/log; then
+    break
+  fi
+  if [ $i -eq 0 ]; then
+    echo no
+    svc -dx svc1/log
+    break
+  fi
+  sleep 1
+done
+echo
+
+echo '--- svscan is stopped'
+if [ $svscanpid -ne 0 ]; then
+  kill -0 $svscanpid 2>/dev/null \
+  && echo no
+fi
+echo
+
+echo '--- readproctitle is stopped'
+if [ $readproctitlepid -ne 0 ]; then
+  kill -0 $readproctitlepid 2>/dev/null \
+  && echo no
+fi
+echo
+
+echo '--- svscanboot is stopped'
+if [ $svscanbootpid -ne 0 ]; then
+  kill -0 $svscanbootpid 2>/dev/null \
+  && echo no
+fi
+echo
+
+echo '--- svscanboot log'
+cat svscanboot.log
+echo
+
+echo '--- svc0 log'
+head -n 1 svc0.log
+echo
+
+echo '--- svc1 main log'
+head -n 1 svc1-main.log
+echo
+
+echo '--- svc1 log log'
+head -n 1 svc1-log.log
+echo
+
+echo
+cd $TOP
+

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -89,6 +89,20 @@ echo svc2-log ran     >> ../svc2-log.log
 exec ../../../sleeper >> ../svc2-log.log
 EOF
 
+timed_read() {
+  for i in 10 9 8 7 6 5 4 3 2 1 0; do
+    if [ -f $1 ]; then
+      cat $1
+      break
+    fi
+    if [ $i -eq 0 ]; then
+      echo 0
+      break
+    fi
+    sleep 1
+  done
+}
+
 echo '--- svscanboot started'
 ./svscanboot service > svscanboot.log 2>&1 &
 svscanbootpid=$!
@@ -105,18 +119,7 @@ fi
 echo
 
 echo '--- svscan started'
-for i in 10 9 8 7 6 5 4 3 2 1 0; do
-  if [ -f svscan.pid ]; then
-    svscanpid=`cat svscan.pid`
-    break
-  fi
-  if [ $i -eq 0 ]; then
-    echo no
-    svscanpid=0
-    break
-  fi
-  sleep 1
-done
+svscanpid=`timed_read svscan.pid`
 echo
 
 echo '--- svscan pid looks sane'
@@ -132,18 +135,7 @@ fi
 echo
 
 echo '--- readproctitle started'
-for i in 10 9 8 7 6 5 4 3 2 1 0; do
-  if [ -f readproctitle.pid ]; then
-    readproctitlepid=`cat readproctitle.pid`
-    break
-  fi
-  if [ $i -eq 0 ]; then
-    echo no
-    readproctitlepid=0
-    break
-  fi
-  sleep 1
-done
+readproctitlepid=`timed_read readproctitle.pid`
 echo
 
 echo '--- readproctitle pid looks sane'

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -55,17 +55,20 @@ test -x svscanboot || die "Could not create svscanboot stub"
 
 catexe svc0/run <<'EOF' || die "Could not create svc0/run script"
 #!/bin/sh
-echo svc0 ran >> ../svc0.log
+echo svc0 ran         >> ../svc0.log
+exec ../../../sleeper >> ../svc0.log
 EOF
 
 catexe svc1/run <<'EOF' || die "Could not create svc1/run script"
 #!/bin/sh
-echo svc1-main ran >> ../svc1-main.log
+echo svc1-main ran    >> ../svc1-main.log
+exec ../../../sleeper >> ../svc1-main.log
 EOF
 
 catexe svc1/log/run <<'EOF' || die "Could not create svc1/log/run script"
 #!/bin/sh
-echo svc1-log ran >> ../../svc1-log.log
+echo svc1-log ran        >> ../../svc1-log.log
+exec ../../../../sleeper >> ../../svc1-log.log
 EOF
 
 echo '--- svscanboot started'
@@ -242,15 +245,15 @@ cat svscanboot.log
 echo
 
 echo '--- svc0 log'
-head -n 1 svc0.log
+cat svc0.log
 echo
 
 echo '--- svc1 main log'
-head -n 1 svc1-main.log
+cat svc1-main.log
 echo
 
 echo '--- svc1 log log'
-head -n 1 svc1-log.log
+cat svc1-log.log
 echo
 
 echo

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -191,60 +191,34 @@ echo '--- sigterm sent'
 kill -TERM $svscanpid || echo no
 echo
 
+timed_ok() {
+  for i in 10 9 8 7 6 5 4 3 2 1 0; do
+    if ! svok $1; then
+      break
+    fi
+    if [ $i -eq 0 ]; then
+      echo no
+      svc -dx $1
+      break
+    fi
+    sleep 1
+  done
+}
+
 echo '--- supervise svc0 is down'
-for i in 10 9 8 7 6 5 4 3 2 1 0; do
-  if ! svok svc0; then
-    break
-  fi
-  if [ $i -eq 0 ]; then
-    echo no
-    svc -dx svc0
-    break
-  fi
-  sleep 1
-done
+timed_ok svc0
 echo
 
 echo '--- supervise svc1 is down'
-for i in 10 9 8 7 6 5 4 3 2 1 0; do
-  if ! svok svc1; then
-    break
-  fi
-  if [ $i -eq 0 ]; then
-    echo no
-    svc -dx svc1
-    break
-  fi
-  sleep 1
-done
+timed_ok svc1
 echo
 
 echo '--- supervise svc1/log is down'
-for i in 10 9 8 7 6 5 4 3 2 1 0; do
-  if ! svok svc1/log; then
-    break
-  fi
-  if [ $i -eq 0 ]; then
-    echo no
-    svc -dx svc1/log
-    break
-  fi
-  sleep 1
-done
+timed_ok svc1/log
 echo
 
 echo '--- supervise svc2 is down'
-for i in 10 9 8 7 6 5 4 3 2 1 0; do
-  if ! svok svc2; then
-    break
-  fi
-  if [ $i -eq 0 ]; then
-    echo no
-    svc -dx svc2
-    break
-  fi
-  sleep 1
-done
+timed_ok svc2
 echo
 
 echo '--- svscan is stopped'

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -122,7 +122,7 @@ echo
 check_pid_sanity() {
   if [ `echo $1 | grep -E '^[1-9][0-9]{0,4}$' | wc -l` != "1" ] \
     || [ $1 -le 1 ]                                             \
-    || [ $1 -ge 65536 ]
+    || [ $1 -ge 99999 ]
   then
     echo 0
   else

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -257,8 +257,9 @@ echo '--- svc1 log log'
 cat svc1-log.log
 echo
 
+# FIXME: on freebsd we get 2 (or more) CONT sigs + TERM
 echo '--- svc2 main log'
-cat svc2-main.log
+cat svc2-main.log | uniq
 echo
 
 echo '--- svc2 log log'

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -266,6 +266,9 @@ echo '--- svc2 log log'
 cat svc2-log.log
 echo
 
+# just in case
+svc -dx svc0 svc1 svc1/log svc2 2>/dev/null
+
 echo
 cd $TOP
 

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -108,14 +108,20 @@ echo '--- svscanboot started'
 svscanbootpid=$!
 echo
 
+check_pid_sanity() {
+  if [ `echo $1 | grep -E '^[1-9][0-9]{0,4}$' | wc -l` != "1" ] \
+    || [ $1 -le 1 ]                                             \
+    || [ $1 -ge 65536 ]
+  then
+    echo 0
+  else
+    echo $1
+  fi
+}
+
 echo '--- svscanboot pid looks sane'
-if [ `echo $svscanbootpid | grep -E '^[1-9][0-9]{0,4}$' | wc -l` != "1" ]; then
-  echo no
-  svscanbootpid=0
-elif [ $svscanbootpid -le 1 ] || [ $svscanbootpid -ge 65536 ]; then
-  echo no
-  svscanbootpid=0
-fi
+svscanbootpid=`check_pid_sanity $svscanbootpid`
+[ "$svscanbootpid" != "0" ] || echo no
 echo
 
 echo '--- svscan started'
@@ -123,15 +129,8 @@ svscanpid=`timed_read svscan.pid`
 echo
 
 echo '--- svscan pid looks sane'
-if [ `echo $svscanpid | grep -E ^[1-9][0-9]*$ | wc -l` != '1' ]
-then
-  echo no
-  svscanpid=0
-elif [ $svscanpid -le 1 ] || [ $svscanpid -ge 65536 ]
-then
-  echo no
-  svscanpid=0
-fi
+svscanpid=`check_pid_sanity $svscanpid`
+[ "$svscanpid" != "0" ] || echo no
 echo
 
 echo '--- readproctitle started'
@@ -139,15 +138,8 @@ readproctitlepid=`timed_read readproctitle.pid`
 echo
 
 echo '--- readproctitle pid looks sane'
-if [ `echo $readproctitlepid | grep -E ^[1-9][0-9]*$ | wc -l` != '1' ]
-then
-  echo no
-  readproctitlepid=0
-elif [ $readproctitlepid -le 1 ] || [ $readproctitlepid -ge 65536 ]
-then
-  echo no
-  readproctitlepid=0
-fi
+readproctitlepid=`check_pid_sanity $readproctitlepid`
+[ "$readproctitlepid" != "0" ] || echo no
 echo
 
 echo '--- svscanboot is running'

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -185,7 +185,11 @@ echo
 
 
 echo '--- sigterm sent'
-kill -TERM $svscanpid || echo no
+if [ "$svscanpid" != "0" ]; then
+  kill -TERM $svscanpid || echo no
+else
+  echo no
+fi
 echo
 
 

--- a/rts.tests/svscan-sigterm.sh
+++ b/rts.tests/svscan-sigterm.sh
@@ -26,6 +26,7 @@ ln -s ../svc0 service || die "Could not link svc0"
 ln -s ../svc1 service || die "Could not link svc1"
 ln -s ../svc2 service || die "Could not link svc2"
 
+
 catexe svscan <<'EOF' || die "Could not create svscan wrapper"
 #!/bin/sh
 PATH=`echo $PATH | cut -d':' -f2-`
@@ -89,6 +90,7 @@ echo svc2-log ran     >> ../svc2-log.log
 exec ../../../sleeper >> ../svc2-log.log
 EOF
 
+
 timed_read() {
   for i in 10 9 8 7 6 5 4 3 2 1 0; do
     if [ -f $1 ]; then
@@ -108,6 +110,15 @@ echo '--- svscanboot started'
 svscanbootpid=$!
 echo
 
+echo '--- svscan started'
+svscanpid=`timed_read svscan.pid`
+echo
+
+echo '--- readproctitle started'
+readproctitlepid=`timed_read readproctitle.pid`
+echo
+
+
 check_pid_sanity() {
   if [ `echo $1 | grep -E '^[1-9][0-9]{0,4}$' | wc -l` != "1" ] \
     || [ $1 -le 1 ]                                             \
@@ -124,23 +135,16 @@ svscanbootpid=`check_pid_sanity $svscanbootpid`
 [ "$svscanbootpid" != "0" ] || echo no
 echo
 
-echo '--- svscan started'
-svscanpid=`timed_read svscan.pid`
-echo
-
 echo '--- svscan pid looks sane'
 svscanpid=`check_pid_sanity $svscanpid`
 [ "$svscanpid" != "0" ] || echo no
-echo
-
-echo '--- readproctitle started'
-readproctitlepid=`timed_read readproctitle.pid`
 echo
 
 echo '--- readproctitle pid looks sane'
 readproctitlepid=`check_pid_sanity $readproctitlepid`
 [ "$readproctitlepid" != "0" ] || echo no
 echo
+
 
 echo '--- svscanboot is running'
 if ! kill -0 $svscanbootpid; then
@@ -179,9 +183,11 @@ echo '--- supervise svc2 is running'
 svok svc2 || echo no
 echo
 
+
 echo '--- sigterm sent'
 kill -TERM $svscanpid || echo no
 echo
+
 
 timed_ok() {
   for i in 10 9 8 7 6 5 4 3 2 1 0; do
@@ -213,6 +219,7 @@ echo '--- supervise svc2 is down'
 timed_ok svc2
 echo
 
+
 timed_ng() {
   if [ $1 -ne 0 ]; then
     for i in 10 9 8 7 6 5 4 3 2 1 0; do
@@ -241,6 +248,7 @@ echo '--- svscanboot is stopped'
 timed_ng $svscanbootpid
 echo
 
+
 echo '--- svscanboot log'
 cat svscanboot.log
 echo
@@ -266,9 +274,9 @@ echo '--- svc2 log log'
 cat svc2-log.log
 echo
 
+
 # just in case
 svc -dx svc0 svc1 svc1/log svc2 2>/dev/null
 
-echo
 cd $TOP
 

--- a/rts.tests/svscan.exp
+++ b/rts.tests/svscan.exp
@@ -1,3 +1,8 @@
+--- svscan setup
+
+--- svscan start
+
+--- svscan out
 ==> svc0/output <==
 svc0 ran
 

--- a/rts.tests/svscan.sh
+++ b/rts.tests/svscan.sh
@@ -1,3 +1,4 @@
+echo '--- svscan setup'
 # set up services
 mkdir service svc0 svc1 svc2 svc2/log
 
@@ -27,7 +28,9 @@ exec cat > ../output
 EOF
 
 ln -s `pwd`/svc[0-9] service/
+echo
 
+echo '--- svscan start'
 svscan `pwd`/service >svscan.log 2>&1 &
 svscanpid=$!
 
@@ -35,6 +38,7 @@ until svok svc0 && svok svc1 && svok svc2 && svok svc2/log
 do
   sleep 1
 done
+echo
 
 # stop svscan and clean up
 kill $svscanpid
@@ -45,6 +49,7 @@ do
   sleep 1
 done
 
+echo '--- svscan out'
 head -n 1 svc[0-9]/output
 cat svscan.log
 rm -r svc0 svc1 svc2 service

--- a/rts.tests/svscan.sh
+++ b/rts.tests/svscan.sh
@@ -40,7 +40,6 @@ done
 kill $svscanpid
 wait >/dev/null 2>&1
 
-svc -dx svc[0-9] svc2/log
 while svok svc0 || svok svc1 || svok svc2 || svok svc2/log
 do
   sleep 1

--- a/rts.tests/svscan.sh
+++ b/rts.tests/svscan.sh
@@ -41,7 +41,8 @@ done
 echo
 
 # stop svscan and clean up
-kill $svscanpid
+kill $svscanpid &
+wait >/dev/null 2>&1
 wait >/dev/null 2>&1
 
 while svok svc0 || svok svc1 || svok svc2 || svok svc2/log

--- a/svscan.8
+++ b/svscan.8
@@ -73,14 +73,16 @@ when it starts.
 
 If
 .B svscan
-receives a TERM signal, it sends TERM signals to all top-level
+receives a TERM signal, it sends TERM signals to all non-log child
 .BR supervise (8)
-processes. The usual five second directory scan is reduced to one second
-and no new processes are started. As each
+processes and the five second service scan is reduced to one second. New
+services are ignored and if a running
+.BR supervise (8)
+stops, it is not restarted. As each existing
 .BR supervise (8)
 exits,
 .B svscan
-sends TERM signals to the corresponding log-level
+sends a TERM signal to the corresponding log
 .BR supervise (8),
 if one exists. After all child processes exit,
 .B svscan

--- a/svscan.8
+++ b/svscan.8
@@ -70,6 +70,19 @@ is given a command-line argument
 it switches to that
 .I directory
 when it starts.
+
+If
+.B svscan
+receives a TERM signal, it will send TERM signals to all top-level
+.BR supervise (8)
+processes then wait for them to exit.
+.B svscan
+then sends TERM signals to all log-level
+.BR supervise (8)
+processes then waits for those to exit.
+.B svscan
+then exits.
+
 .SH SEE ALSO
 envdir(8),
 envini(8),

--- a/svscan.8
+++ b/svscan.8
@@ -73,15 +73,18 @@ when it starts.
 
 If
 .B svscan
-receives a TERM signal, it will send TERM signals to all top-level
+receives a TERM signal, it sends TERM signals to all top-level
 .BR supervise (8)
-processes then wait for them to exit.
-.B svscan
-then sends TERM signals to all log-level
+processes. The usual five second directory scan is reduced to one second
+and no new processes are started. As each
 .BR supervise (8)
-processes then waits for those to exit.
+exits,
 .B svscan
-then exits.
+sends TERM signals to the corresponding log-level
+.BR supervise (8),
+if one exists. After all child processes exit,
+.B svscan
+exits.
 
 .SH SEE ALSO
 envdir(8),

--- a/svscan.c
+++ b/svscan.c
@@ -65,7 +65,7 @@ void start(const char *fn)
   for (i = 0;i < numx;++i)
     if (x[i].ino == st.st_ino)
       if (x[i].dev == st.st_dev)
-	break;
+        break;
 
   if (i == numx) {
     if (numx >= SERVICES) {
@@ -83,12 +83,12 @@ void start(const char *fn)
       byte_copy(fnlog,fnlen,fn);
       byte_copy(fnlog + fnlen,5,"/log");
       if (stat(fnlog,&st) == 0)
-	x[i].flaglog = S_ISDIR(st.st_mode);
+        x[i].flaglog = S_ISDIR(st.st_mode);
       else
-	if (errno != error_noent) {
+        if (errno != error_noent) {
           strerr_warn4sys(WARNING,"unable to stat ",fn,"/log");
           return;
-	}
+    }
     }
 
     if (x[i].flaglog) {
@@ -111,18 +111,18 @@ void start(const char *fn)
         return;
       case 0:
         if (x[i].flaglog)
-	  if (fd_move(1,x[i].pi[1]) == -1)
+          if (fd_move(1,x[i].pi[1]) == -1)
             strerr_die3sys(111,WARNING,"unable to set up descriptors for ",fn);
-	if (i == logx)
-	  if (fd_move(0,logpipe[0]) == -1)
-	    strerr_die3sys(111,WARNING,"unable to set up descriptors for ",fn);
+        if (i == logx)
+          if (fd_move(0,logpipe[0]) == -1)
+            strerr_die3sys(111,WARNING,"unable to set up descriptors for ",fn);
         args[0] = "supervise";
         args[1] = fn;
         args[2] = 0;
-	pathexec_run(*args,args,(const char*const*)environ);
+        pathexec_run(*args,args,(const char*const*)environ);
         strerr_die3sys(111,WARNING,"unable to start supervise ",fn);
       default:
-	x[i].pid = child;
+        x[i].pid = child;
         exit_now = 0;
     }
   else
@@ -140,15 +140,15 @@ void start(const char *fn)
       case 0:
         if (fd_move(0,x[i].pi[0]) == -1)
           strerr_die4sys(111,WARNING,"unable to set up descriptors for ",fn,"/log");
-	if (chdir(fn) == -1)
+        if (chdir(fn) == -1)
           strerr_die3sys(111,WARNING,"unable to switch to ",fn);
         args[0] = "supervise";
         args[1] = "log";
         args[2] = 0;
-	pathexec_run(*args,args,(const char*const*)environ);
+        pathexec_run(*args,args,(const char*const*)environ);
         strerr_die4sys(111,WARNING,"unable to start supervise ",fn,"/log");
       default:
-	x[i].pidlog = child;
+        x[i].pidlog = child;
         exit_now = 0;
     }
   else

--- a/svscan.c
+++ b/svscan.c
@@ -264,7 +264,7 @@ int main(int argc,char **argv)
     exit_now = 1;
     doit();
     if (exit_now) break;
-    sleep(5);
+    sleep(exit_soon ? 1 : 5);
   }
   return 0;
 }

--- a/svscan.c
+++ b/svscan.c
@@ -1,6 +1,8 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <signal.h>
+#include "sig.h"
 #include "direntry.h"
 #include "strerr.h"
 #include "error.h"
@@ -32,8 +34,14 @@ int numx = 0;
 int logx = -1;
 int logpipe[2];
 const char *logdir = 0;
+int exit_now, exit_soon=0;
 
 char fnlog[260];
+
+void catch_sig(int sig)
+{
+  exit_soon = 1;
+}
 
 void start(const char *fn)
 {
@@ -96,7 +104,7 @@ void start(const char *fn)
 
   x[i].flagactive = 1;
 
-  if (!x[i].pid)
+  if (!x[i].pid && !exit_soon)
     switch(child = fork()) {
       case -1:
         strerr_warn4sys(WARNING,"unable to fork for ",fn,"");
@@ -115,9 +123,16 @@ void start(const char *fn)
         strerr_die3sys(111,WARNING,"unable to start supervise ",fn);
       default:
 	x[i].pid = child;
+        exit_now = 0;
+    }
+  else
+    if (x[i].pid) {
+      exit_now = 0;
+      if (exit_soon)
+        kill(x[i].pid,SIGTERM);
     }
 
-  if (x[i].flaglog && !x[i].pidlog)
+  if (x[i].flaglog && !x[i].pidlog && !exit_soon)
     switch(child = fork()) {
       case -1:
         strerr_warn4sys(WARNING,"unable to fork for ",fn,"/log");
@@ -134,6 +149,13 @@ void start(const char *fn)
         strerr_die4sys(111,WARNING,"unable to start supervise ",fn,"/log");
       default:
 	x[i].pidlog = child;
+        exit_now = 0;
+    }
+  else
+    if (x[i].flaglog && x[i].pidlog) {
+      exit_now = 0;
+      if (exit_soon && !x[i].pid)
+        kill(x[i].pidlog,SIGTERM);
     }
 }
 
@@ -236,9 +258,13 @@ int main(int argc,char **argv)
     logdir = argv[2];
 
   start_log();
+  sig_catch(SIGTERM,catch_sig);
 
   for (;;) {
+    exit_now = 1;
     doit();
+    if (exit_now) break;
     sleep(5);
   }
+  return 0;
 }


### PR DESCRIPTION
This patch addresses issue #30 - catching and propagating SIGTERM to child supervise processes in svscan for Docker. It adds a sigterm handler, a new test, and updates the svscan man page.

<... snip ...>
If svscan receives a TERM signal, it sends TERM signals to all non-log child supervise(8) processes and the five second service scan is reduced to one second. New services are ignored and if a running supervise(8) stops, it is not restarted. As each existing supervise(8) exits, svscan sends a TERM signal to the corresponding log supervise(8), if one exists. After all child processes exit, svscan exits.
