### PR TITLE
initialize supervise log time

### DIFF
--- a/rts.tests/supervise-downtime.exp
+++ b/rts.tests/supervise-downtime.exp
@@ -1,0 +1,3 @@
+--- supervise has reasonable downtimes
+test.sv: down ok
+test.sv log: down ok

--- a/rts.tests/supervise-downtime.sh
+++ b/rts.tests/supervise-downtime.sh
@@ -1,0 +1,32 @@
+echo '--- supervise has reasonable downtimes'
+
+rm -rf test.sv/*
+
+catexe test.sv/run <<EOF
+#!/bin/sh
+sleep 999
+EOF
+
+catexe test.sv/log <<EOF
+#!/bin/sh
+sleep 999
+EOF
+
+touch test.sv/down
+
+supervise test.sv &
+svpid=$!
+
+until svok test.sv
+do
+  sleep 1
+done
+
+svstat test.sv \
+| sed -r 's, \(.+\),,' \
+| sed -r 's, ([0-9]|1[0-9]) second.+$, ok,'
+
+kill $svpid
+wait
+
+rm -rf test.sv/*

--- a/supervise.c
+++ b/supervise.c
@@ -161,6 +161,7 @@ void announce(void)
   if (logpipe[0] < 0)
     w = 20;
   else {
+    taia_now(&svclog.when);
     make_status(&svclog,status + 20);
     w = 40;
   }

--- a/supervise.c
+++ b/supervise.c
@@ -161,7 +161,6 @@ void announce(void)
   if (logpipe[0] < 0)
     w = 20;
   else {
-    taia_now(&svclog.when);
     make_status(&svclog,status + 20);
     w = 40;
   }
@@ -484,6 +483,7 @@ int main(int argc,char **argv)
     strerr_die3sys(111,FATAL,"unable to write ",fntemp);
   closeonexec(fdcontrolwrite);
 
+  taia_now(&svclog.when);
   pidchange(&svcmain,0,0,0);
 
   if ((fntemp = svpath_make("/ok")) == 0) die_nomem();


### PR DESCRIPTION
This fixes a bug in supervise-managed log services. If you start the service "down", the initial downtime reported by svstat is phenominal.

```
$ echo '#!/bin/sh' > run
$ echo 'sleep 999' >> run
$ chmod +x run
$ cp run log
$ touch down
$ supervise . &
$ svstat .
.: down 3 seconds, starting
. log: down 46116801996288800 seconds, starting
```
