### PR TITLE
supervise: fix initial "down" status

### DIFF
--- a/supervise.c
+++ b/supervise.c
@@ -48,8 +48,8 @@ int firstrun = 1;
 const char *runscript = 0;
 
 int logpipe[2] = {-1,-1};
-struct svc svcmain = {0,svstatus_starting,1,1};
-struct svc svclog = {0,svstatus_starting,1,0};
+struct svc svcmain = {0,svstatus_stopped,1,1};
+struct svc svclog = {0,svstatus_stopped,1,0};
 
 static int stat_isexec(const char *path)
 {


### PR DESCRIPTION
When a supervised service is started in the "down" state, svstat claims the service is "starting", which isn't true. For example:

```
> cat <<EOF > sv/run
> #!/bin/sh
> sleep 999
> EOF
> chmod 755 sv/run
> touch sv/down
> supervise sv &
> svstat sv
sv: down 2 seconds, starting
```
This patch fixes that by simply changing the initial state.

```
sv: down 2 seconds, stopped
```
Cycling this service up and back down report the states correctly, as well as the initial and subsequent states of normally up services.

Ditto for supervised managed logging services, however see my other patch for fixing the astronomical initial downtime of normally down services.