### PR TITLE
supervise: acquire lock sooner

### DIFF
--- a/supervise.c
+++ b/supervise.c
@@ -444,6 +444,16 @@ int main(int argc,char **argv)
   if (!svpath_init())
     strerr_die3sys(111,FATAL,"unable to setup control path for ",dir);
 
+  if ((fntemp = svpath_make("")) == 0) die_nomem();
+  if (mkdir(fntemp,0700) != 0 && errno != error_exist)
+    strerr_die3sys(111,FATAL,"unable to create ",fntemp);
+
+  if ((fntemp = svpath_make("/lock")) == 0) die_nomem();
+  fdlock = open_append(fntemp);
+  if ((fdlock == -1) || (lock_exnb(fdlock) == -1))
+    strerr_die3sys(111,FATAL,"unable to acquire ",fntemp);
+  closeonexec(fdlock);
+
   if (stat_isexec("log") > 0) {
     if (pipe(logpipe) != 0)
       strerr_die3sys(111,FATAL,"unable to create pipe for ",dir);
@@ -457,19 +467,11 @@ int main(int argc,char **argv)
     if (errno != error_noent)
       strerr_die4sys(111,FATAL,"unable to stat ",dir,"/down");
 
-  if ((fntemp = svpath_make("")) == 0) die_nomem();
-  if (mkdir(fntemp,0700) != 0 && errno != error_exist)
-    strerr_die3sys(111,FATAL,"unable to create ",fntemp);
   if ((fntemp = svpath_make("/status")) == 0) die_nomem();
   fdstatus = open_trunc(fntemp);
   if (fdstatus == -1)
     strerr_die4sys(111,FATAL,"unable to open ",fntemp," for writing");
   closeonexec(fdstatus);
-  if ((fntemp = svpath_make("/lock")) == 0) die_nomem();
-  fdlock = open_append(fntemp);
-  if ((fdlock == -1) || (lock_exnb(fdlock) == -1))
-    strerr_die3sys(111,FATAL,"unable to acquire ",fntemp);
-  closeonexec(fdlock);
 
   if ((fntemp = svpath_make("/control")) == 0) die_nomem();
   fifo_make(fntemp,0600);


### PR DESCRIPTION
If a second supervise is started in a service directory, it clobbers the existing status file even though it aborts. For example:

```
> mkdir t
> cat <<EOF > t/run
> #!/bin/sh
> exec /bin/sleep 999
> EOF
> chmod 755 t/run
> supervise t &
> svstat t
t: up (pid 4070) 3 seconds, running
> supervise t
supervise: fatal: unable to acquire supervise/lock: temporary failure
> svstat t
t: unable to read supervise/status: bad format
```

This patch works by reversing the order of open_trunc("status") and open_append("lock") so that the lock is acquired first. It also moves mkdir() and open_append() up to allow supervise to bail out sooner.

```
> supervise t &
> svstat t
t: up (pid 7279) 2 seconds, running
> supervise t
supervise: fatal: unable to acquire supervise/lock: temporary failure
> svstat t
t: up (pid 7279) 7 seconds, running
```
