### PR TITLE
supervise: use iopause instead of deepsleep for throttling

### DIFF
--- a/supervise.c
+++ b/supervise.c
@@ -234,6 +234,8 @@ void trystart(struct svc *svc)
   taia_now(&now);
   taia_uint(&svc->after,1);
   taia_add(&svc->after,&svc->after,&now);
+  if (svc == &svclog)
+    svcmain.after = svclog.after;
 }
 
 void trystop(struct svc *svc)


### PR DESCRIPTION
This patch "fixes" the freeze-up in supervise each time a new service instance is launched by removing the call to deepsleep() in try_start(). However, to achieve the same throttling effect, it is replaced with a per-service timestamp which is checked before forking again and a call to iopause().

In effect, the "freeze" point is completely removed when dealing with well-behaved services. For quick finishers that exit other than 100, throttling comes into play. And those that exit 100 are marked for immediate restart on the theory that intentional external action is required.

And the reason for this patch is mainly to speed up the test suite, although it might also help with some of the already outstanding issues. On my machine the tests ran in 17s patched vs. 27s stock, or 58% faster, and can probably be trimmed further with tweaking to leverage the exit 100 bit.