### PR TITLE
trymemrchr.c typo and missing define

### DIFF
--- a/print-cc.sh
+++ b/print-cc.sh
@@ -2,4 +2,7 @@ cc="`head -1 conf-cc`"
 systype="`cat systype`"
 
 cat warn-auto.sh
-echo exec "$cc" '-c ${1+"$@"}'
+echo exec "$cc" -D_GNU_SOURCE '-c ${1+"$@"}'
+
+# Feature Test Macro Requirements for glibc (see feature_test_macros(7)):
+#   memrchr(): _GNU_SOURCE

--- a/trymemrchr.c
+++ b/trymemrchr.c
@@ -6,5 +6,5 @@ int main()
 {
   char try[1];
   memrchr(try,1,1);
-  return 0
+  return 0;
 }


### PR DESCRIPTION
This patch fixes a config-time typo in trymemrchr.c and subsequent missing define to make memrchr visible from glibc, at least on Linux.