### PR TITLE
fix gcc-7.3 warnings

### DIFF
--- a/byte_rchr.c
+++ b/byte_rchr.c
@@ -17,10 +17,10 @@ unsigned int byte_rchr(const char *s,unsigned int n,int c)
   t = s;
   u = 0;
   for (;;) {
-    if (!n) break; if (*t == ch) u = t; ++t; --n;
-    if (!n) break; if (*t == ch) u = t; ++t; --n;
-    if (!n) break; if (*t == ch) u = t; ++t; --n;
-    if (!n) break; if (*t == ch) u = t; ++t; --n;
+    if (!n) {break;} if (*t == ch) {u = t;} ++t; --n;
+    if (!n) {break;} if (*t == ch) {u = t;} ++t; --n;
+    if (!n) {break;} if (*t == ch) {u = t;} ++t; --n;
+    if (!n) {break;} if (*t == ch) {u = t;} ++t; --n;
   }
   if (!u) u = t;
   return u - s;

--- a/fghack.c
+++ b/fghack.c
@@ -48,4 +48,6 @@ int main(int argc,const char * const *argv,const char * const *envp)
   if (wait_crashed(wstat))
     strerr_die2x(111,FATAL,"child crashed");
   _exit(wait_exitcode(wstat));
+  /* avoid warning */
+  if (ignored) {}
 }

--- a/sleeper.c
+++ b/sleeper.c
@@ -29,6 +29,8 @@ static void catch_sig(int sig)
   ignored = write(1,buf,i);
   if (sig != SIGCONT)
     _exit(1);
+  /* avoid warning */
+  if (ignored) {}
 }
 
 int main(void)

--- a/str_chr.c
+++ b/str_chr.c
@@ -10,10 +10,10 @@ unsigned int str_chr(const char *s,int c)
   ch = c;
   t = s;
   for (;;) {
-    if (!*t) break; if (*t == ch) break; ++t;
-    if (!*t) break; if (*t == ch) break; ++t;
-    if (!*t) break; if (*t == ch) break; ++t;
-    if (!*t) break; if (*t == ch) break; ++t;
+    if (!*t) {break;} if (*t == ch) {break;} ++t;
+    if (!*t) {break;} if (*t == ch) {break;} ++t;
+    if (!*t) {break;} if (*t == ch) {break;} ++t;
+    if (!*t) {break;} if (*t == ch) {break;} ++t;
   }
   return t - s;
 }

--- a/supervise.c
+++ b/supervise.c
@@ -76,6 +76,8 @@ static void trigger(void)
 {
   int ignored;
   ignored = write(selfpipe[1],"",1);
+  /* avoid warning */
+  if (ignored) {}
 }
 
 static void terminate(void)
@@ -83,6 +85,8 @@ static void terminate(void)
   int ignored;
   ignored = write(fdcontrolwrite,"dx",2);
   ignored = write(selfpipe[1],"",1);
+  /* avoid warning */
+  if (ignored) {}
 }
 
 static void ttystop(void)
@@ -90,6 +94,8 @@ static void ttystop(void)
   int ignored;
   ignored = write(fdcontrolwrite,"p",1);
   ignored = write(selfpipe[1],"",1);
+  /* avoid warning */
+  if (ignored) {}
 }
 
 static void resume(void)
@@ -97,6 +103,8 @@ static void resume(void)
   int ignored;
   ignored = write(fdcontrolwrite,"c",1);
   ignored = write(selfpipe[1],"",1);
+  /* avoid warning */
+  if (ignored) {}
 }
 
 static int forkexecve(struct svc *svc,const char *argv[],int fd)


### PR DESCRIPTION
This patch fixes various unused-but-set-variable and misleading-indentation warnings generated by -Wall on newer gcc.