### PR TITLE
supervise: use iopause instead of deepsleep for throttling

### DIFF
--- a/supervise.c
+++ b/supervise.c
@@ -33,6 +33,7 @@ struct svc
   int flagpaused;
   struct taia when;
   int ranstop;
+  struct taia after;
 };
 
 const char *dir;
@@ -205,6 +206,7 @@ void trystart(struct svc *svc)
   const char *argv[] = { 0,0 };
   int f;
   int fd;
+  struct taia now;
 
   if (svc == &svclog) {
     argv[0] = "./log";
@@ -224,10 +226,16 @@ void trystart(struct svc *svc)
     svcmain.flagstatus = firstrun ? svstatus_starting : svstatus_running;
     fd = 1;
   }
+  taia_now(&now);
+  iopause(0,0,&svc->after,&now);
   if ((f = forkexecve(svc,argv,fd)) < 0)
     return;
   pidchange(svc,"start",0,f);
-  deepsleep(1);
+  taia_now(&now);
+  taia_uint(&svc->after,1);
+  taia_add(&svc->after,&svc->after,&now);
+  if (svc == &svclog)
+    svcmain.after = svclog.after;
 }
 
 void trystop(struct svc *svc)
@@ -304,10 +312,14 @@ void doit(void)
 	continue;
       killpid = svc->pid;
       svc->pid = 0;
-      if ((firstrun && (wait_crashed(wstat) || wait_exitcode(wstat) != 0))
-	   || (!wait_crashed(wstat) && wait_exitcode(wstat) == 100)) {
-	svc->flagwantup = 0;
-	svc->flagstatus = svstatus_failed;
+      if (firstrun && (wait_crashed(wstat) || wait_exitcode(wstat) != 0)) {
+        svc->flagwantup = 0;
+        svc->flagstatus = svstatus_failed;
+      }
+      if (!wait_crashed(wstat) && wait_exitcode(wstat) == 100) {
+        svc->flagwantup = 0;
+        svc->flagstatus = svstatus_failed;
+        taia_now(&svc->after);
       }
       else if (!svc->flagwant || !svc->flagwantup)
 	svc->flagstatus = svstatus_stopped;
@@ -494,6 +506,9 @@ int main(int argc,char **argv)
   if (fdok == -1)
     strerr_die3sys(111,FATAL,"unable to read ",fntemp);
   closeonexec(fdok);
+
+  taia_now(&svclog.after);
+  svcmain.after = svclog.after;
 
   if (!svclog.flagwant || svclog.flagwantup) trystart(&svclog);
   if (!svcmain.flagwant || svcmain.flagwantup) trystart(&svcmain);


### PR DESCRIPTION
This patch "fixes" the freeze-up in supervise each time a new service instance is launched by removing the call to deepsleep() in try_start(). However, to achieve the same throttling effect, it is replaced with a per-service timestamp which is checked before forking again and a call to iopause().

In effect, the "freeze" point is completely removed when dealing with well-behaved services. For quick finishers that exit other than 100, throttling comes into play. And those that exit 100 are marked for immediate restart on the theory that intentional external action is required.

And the reason for this patch is mainly to speed up the test suite, although it might also help with some of the already outstanding issues. On my machine the tests ran in 17s patched vs. 27s stock, or 58% faster, and can probably be trimmed further with tweaking to leverage the exit 100 bit.