### PR TITLE
supervise: start "down" services with svc -o

### DIFF
--- a/rts.tests/supervise-start.exp
+++ b/rts.tests/supervise-start.exp
@@ -1,0 +1,2 @@
+--- svc -o works first time with start
+ok

--- a/rts.tests/supervise-start.sh
+++ b/rts.tests/supervise-start.sh
@@ -1,0 +1,34 @@
+echo '--- svc -o works first time with start'
+catexe test.sv/run <<EOF
+#!/bin/sh
+echo ok > out
+svc -dx .
+EOF
+catexe test.sv/start <<EOF
+#!/bin/sh
+exit 0
+EOF
+touch test.sv/down
+supervise test.sv &
+svpid=$!
+until svok test.sv
+do
+  sleep 1
+done
+svc -o test.sv
+for c in 1 2 3 4 5 6 7 8
+do
+  if [ -e test.sv/out ]
+  then
+    break
+  fi
+  sleep 1
+done
+if [ -e test.sv/out ]
+then
+  cat test.sv/out
+else
+  kill $svpid
+fi
+wait
+rm -f test.sv/start test.sv/down test.sv/out

--- a/supervise.c
+++ b/supervise.c
@@ -308,10 +308,12 @@ void doit(void)
 	continue;
       killpid = svc->pid;
       svc->pid = 0;
-      if ((firstrun && (wait_crashed(wstat) || wait_exitcode(wstat) != 0))
-	   || (!wait_crashed(wstat) && wait_exitcode(wstat) == 100)) {
+      if (((svc == &svcmain && svc->flagstatus == svstatus_starting) && (wait_crashed(wstat) || wait_exitcode(wstat) != 0))
+	    || (!wait_crashed(wstat) && wait_exitcode(wstat) == 100)) {
 	svc->flagwantup = 0;
 	svc->flagstatus = svstatus_failed;
+      }
+      else if (svc == &svcmain && svc->flagstatus == svstatus_starting) {
       }
       else if (!svc->flagwant || !svc->flagwantup)
 	svc->flagstatus = svstatus_stopped;
@@ -319,7 +321,7 @@ void doit(void)
 		wait_crashed(wstat) ? wait_stopsig(wstat) : wait_exitcode(wstat),
 		killpid);
       firstrun = 0;
-      if (svc->flagwant && svc->flagwantup) {
+      if ((svc->flagwant && svc->flagwantup) || (svc == &svcmain && svc->flagstatus == svstatus_starting)) {
 	if (!flagexit)
 	  trystart(svc);
       }


### PR DESCRIPTION
Continued from PR#47.
This patch addresses issue #32. Basically, the firstrun flag is only valid until the start script is launched but the reaper code is trying to use it later to decide what to do.