### PR TITLE
Portability fix: Avoid the use of sed -r

### DIFF
--- a/rts.tests/supervise-downtime.sh
+++ b/rts.tests/supervise-downtime.sh
@@ -20,8 +20,8 @@ svpid=$!
 waitok test.sv
 
 svstat test.sv \
-| sed -r 's, \(.+\),,' \
-| sed -r 's, ([0-9]|1[0-9]) second.+$, ok,'
+| sed 's, (..*),,' \
+| sed 's! 1\{0,1\}[0-9] second..*$! ok!'
 
 kill $svpid
 wait


### PR DESCRIPTION
Legacy sed does not support -r option (use extended regular expressions)