### PR TITLE
Omit any SELinux trailing dot from ls to fix test.

### DIFF
--- a/rts.tests/supervise-lock.sh
+++ b/rts.tests/supervise-lock.sh
@@ -1,9 +1,9 @@
 echo '--- supervise leaves locked service intact'
 supervise test.sv &
 waitok test.sv
-( cd test.sv/supervise && ls -dl * | awk '{ print $1, $5, $9 }' )
+( cd test.sv/supervise && ls -dl * | awk '{ print substr($1,1,10), $5, $9 }' )
 supervise test.sv; echo $?
-( cd test.sv/supervise && ls -dl * | awk '{ print $1, $5, $9 }' )
+( cd test.sv/supervise && ls -dl * | awk '{ print substr($1,1,10), $5, $9 }' )
 svc -x test.sv; echo $?
 wait
 svstat test.sv; echo $?


### PR DESCRIPTION
I saw these test failures on at least CentOS 6 and 7:

```diff
@@ -269,16 +269,16 @@
 test.sv: down ok
 test.sv log: down ok
 --- supervise leaves locked service intact
-prw------- 0 control
--rw------- 0 lock
-prw------- 0 ok
--rw-r--r-- 20 status
+prw-------. 0 control
+-rw-------. 0 lock
+prw-------. 0 ok
+-rw-r--r--. 20 status
 supervise: fatal: unable to acquire supervise/lock: temporary failure
 111
-prw------- 0 control
--rw------- 0 lock
-prw------- 0 ok
--rw-r--r-- 20 status
+prw-------. 0 control
+-rw-------. 0 lock
+prw-------. 0 ok
+-rw-r--r--. 20 status
 0
 test.sv: supervise not running
 0
```

The trailing `.` evidently means a file has some SELinux context (which can then be viewed with `ls -Z`). For this test's purposes, we can just leave it out.